### PR TITLE
lexitrail: point support at support@lexitrail.com, not support@yojowa.com

### DIFF
--- a/ui/src/components/PrivacyPolicy.js
+++ b/ui/src/components/PrivacyPolicy.js
@@ -57,7 +57,7 @@ const PrivacyPolicy = () => {
 
           <section>
             <h2>Contact</h2>
-            <p>If you have any questions about this Privacy Policy, please contact us at: support@yojowa.com</p>
+            <p>If you have any questions about this Privacy Policy, please contact us at: support@lexitrail.com</p>
           </section>
         </div>
       </div>

--- a/ui/src/components/TermsOfService.js
+++ b/ui/src/components/TermsOfService.js
@@ -68,7 +68,7 @@ const TermsOfService = () => {
 
                     <section>
                         <h2>Contact</h2>
-                        <p>If you have any questions about these Terms of Service, please contact us at: support@yojowa.com</p>
+                        <p>If you have any questions about these Terms of Service, please contact us at: support@lexitrail.com</p>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
Privacy Policy and Terms of Service both tell users to contact `support@yojowa.com`. That is the wrong address for this product — every other Yojowa site points at its own `support@` — and it is the **only** contact address lexitrail.com shows anywhere, so a user with a question has exactly one route and it is the wrong one.

Verified on the live site: `https://lexitrail.com/privacy` renders `support@yojowa.com` today.

Alex, 2026-08-22: *"Each site should have support@ present — support@familylore.ai, support@lexitrail.com, support@stockmap.io, support@withby.ai."* The other three already do; lexitrail was the only gap.

**Two lines, text only, no behaviour change.** Raised as a PR rather than pushed to main because main is protected — needs a reviewer from the hermes crew.

Filed by zz3 (Alex's session).